### PR TITLE
Add support for gpg keys with password

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Where the `GPG_KEY_ID` is the email address that you used in the previous step.
 
 There are a few things that still need to be added to the project to get it to a complete state. They are listed below:
 
-- [ ] Add the ability to specify a passphrase
 - [ ] Add the ability to specify a path to the GPG key instead of using an environment variable
 - [ ] Add the ability to force reveal the secrets (sometimes you may want to overwrite existing files)
 

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,12 @@ inputs:
   gpg-private-key:
     description: 'The GPG private key to use, you can export this using the command: gpg --armour --export-secret-keys KEY_ID'
     required: true
+  gpg-private-key-passphrase:
+    description: 'The passphrase for the private key, if any'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.gpg-private-key }}
+    - ${{ inputs.gpg-private-key-passphrase }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,10 @@
 
 echo "Revealing the secrets in the repository..."
 
-echo "$1" > /root/gpg
+echo "$1" | gpg --no-tty --batch --import
 
-gpg --import /root/gpg
+if [ ! -z "$2" ]; then
+  pass_arg="-p $2"
+fi
 
-git secret reveal
+git secret reveal $pass_arg


### PR DESCRIPTION
A new (optional) option `gpg-private-key-passphrase` has been added, which can be used to specify the passphrase for the GPG key.
