### PR TITLE
fix(passphrase): Escape the passphrase so that special characters don't affect the bash script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,4 +15,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.gpg-private-key }}
-    - ${{ inputs.gpg-private-key-passphrase }}
+    - "${{ inputs.gpg-private-key-passphrase }}"

--- a/action.yml
+++ b/action.yml
@@ -15,4 +15,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.gpg-private-key }}
-    - "${{ inputs.gpg-private-key-passphrase }}"
+    - ${{ inputs.gpg-private-key-passphrase }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,13 +6,11 @@ echo "Revealing the secrets in the repository..."
 
 echo "$1" | gpg --no-tty --batch --import
 
-q_mid=\'\\\'\'
-pass_esc="'${2//\'/$q_mid}'"
-if [ "$pass_esc" != "''" ]; then
+if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  pass_arg="-p ${pass_esc}"
+  pass_arg="-p \"$2\""
 fi
 
 git secret reveal $pass_arg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  printf %q "$2" | xargs git secret reveal -p
+  printf "%s" "$2" | xargs git secret reveal -p
 else
   git secret reveal
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  pass_arg="-p \"$2\""
+  echo $2 | xargs git secret reveal -p
+else
+  git secret reveal
 fi
-
-git secret reveal $pass_arg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,12 +4,13 @@ echo "Revealing the secrets in the repository..."
 
 echo "$1" | gpg --no-tty --batch --import
 
-if [ ! -z "$2" ]; then
+q_mid=\'\\\'\'
+pass_esc="'${2//\'/$q_mid}'"
+if [ ! -z "$pass_esc" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
-  q_mid=\'\\\'\'
-  pass_esc="'${2//\'/$q_mid}'"
-  pass_arg="-p \"${pass_esc}\""
+
+  pass_arg="-p ${pass_esc}"
 fi
 
 git secret reveal $pass_arg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ echo "$1" | gpg --no-tty --batch --import
 
 q_mid=\'\\\'\'
 pass_esc="'${2//\'/$q_mid}'"
-if [ ! -z "$pass_esc" ]; then
+if [ "$pass_esc" != "''" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,11 @@ echo "Revealing the secrets in the repository..."
 echo "$1" | gpg --no-tty --batch --import
 
 if [ ! -z "$2" ]; then
-  pass_arg="-p \"${2@Q}\""
+  # Check this link to see why we use the @Q
+  # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
+  q_mid=\'\\\'\'
+  pass_esc="'${2//\'/$q_mid}'"
+  pass_arg="-p \"${pass_esc}\""
 fi
 
 git secret reveal $pass_arg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  echo $2 | xargs git secret reveal -p
+  echo printf '%q' "$" | xargs git secret reveal -p
 else
   git secret reveal
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  echo printf '%q' "$" | xargs git secret reveal -p
+  printf '%q' "$2" | xargs git secret reveal -p
 else
   git secret reveal
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,8 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  git secret reveal -p $(printf "%s" "$2")
+  escaped_pass=$(printf "%s" "$2")
+  git secret reveal -p "${escaped_pass}"
 else
   git secret reveal
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ echo "Revealing the secrets in the repository..."
 echo "$1" | gpg --no-tty --batch --import
 
 if [ ! -z "$2" ]; then
-  pass_arg="-p $2"
+  pass_arg="-p \"${2@Q}\""
 fi
 
 git secret reveal $pass_arg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  printf "%s" "$2" | xargs git secret reveal -p
+  git secret reveal -p $(printf "%s" "$2")
 else
   git secret reveal
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 echo "Revealing the secrets in the repository..."
 
 echo "$1" | gpg --no-tty --batch --import

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]; then
   # Check this link to see why we use the @Q
   # https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
 
-  printf '%q' "$2" | xargs git secret reveal -p
+  printf %q "$2" | xargs git secret reveal -p
 else
   git secret reveal
 fi


### PR DESCRIPTION
# Type
- Fix

# Completed
- Escape the passphrase so that special characters don't break the script
- Use `printf` in the script for escaping