### PR TITLE
Add action types

### DIFF
--- a/.github/workflows/action-types.yml
+++ b/.github/workflows/action-types.yml
@@ -1,0 +1,13 @@
+name: Validate action typings
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-typings:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: krzema12/github-actions-typing@v0

--- a/.github/workflows/action-types.yml
+++ b/.github/workflows/action-types.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      - uses: krzema12/github-actions-typing@v0
+      - uses: typesafegithub/github-actions-typing@v1

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,5 @@
+inputs:
+  gpg-private-key: 
+    type: string
+  gpg-private-key-passphrase:
+    type: string


### PR DESCRIPTION
Github Actions YAML usually isn't as useful as it could be.

https://github.com/krzema12/github-actions-typing

This project setup a way to define types for github actions inputs to build a type-safe DSL.

This commit implements both the typing for this action and the workflow to verify it.