### PR TITLE
fix(build): add gnupg-keyboxd dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --update \
     bash \
     gpg \
     gpg-agent \
+    gnupg-keyboxd \
     git \
     gawk \
     && rm -rf /var/cache/apk/*


### PR DESCRIPTION
My builds suddenly started failing with the following error in the log:

```
Revealing the secrets in the repository...
gpg: error running '/usr/libexec/keyboxd': probably not installed
You have got a passphrase set for your key, revealing the secrets using this code...
gpg: failed to start keyboxd '/usr/libexec/keyboxd': Configuration error
gpg: can't connect to the keyboxd: Configuration error
gpg: error opening key DB: No Keybox daemon running
gpg: key <KEY_ID>: public key not found: I/O error
gpg: error running '/usr/libexec/keyboxd': probably not installed
gpg: failed to start keyboxd '/usr/libexec/keyboxd': Configuration error
gpg: can't connect to the keyboxd: Configuration error
gpg: error opening key DB: No Keybox daemon running
gpg: key <KEY_ID>: failed to re-lookup public key: I/O error
gpg: error reading '[stdin]': I/O error
gpg: import from '[stdin]' failed: I/O error
gpg: Total number processed: 0
gpg:       secret keys read: 1
gpg: error running '/usr/libexec/keyboxd': probably not installed
gpg: failed to start keyboxd '/usr/libexec/keyboxd': Configuration error
gpg: can't connect to the keyboxd: Configuration error
gpg: error opening key DB: No Keybox daemon running
gpg: public key decryption failed: No secret key
gpg: decryption failed: No secret key
```

I'm not exactly sure what the trigger was, but it could have something to do with this [recent release](https://dev.gnupg.org/source/gnupg/browse/master/NEWS$8) of GPG (as alluded to [here](https://github.com/codecov/codecov-circleci-orb/issues/157)). 

Looks like others have seen the same:
 - https://github.com/actionhippie/kubectl/issues/30 (fix here: https://github.com/actionhippie/kustomize/commit/7559451011a59a7be873ae558fabdecb014ef6ca)
 - https://github.com/bats-core/bats-core/issues/723

This PR simply adds `gnupg-keyboxd` as an additional package installed a part of the docker build. In my testing, it fixes the issue without fuss.